### PR TITLE
Make the press reaction more visible

### DIFF
--- a/chai/src/main/java/com/droidconke/chai/colors/ChaiColors.kt
+++ b/chai/src/main/java/com/droidconke/chai/colors/ChaiColors.kt
@@ -36,7 +36,7 @@ data class ChaiColors(
     val activeBottomNavIconColor: Color = Color.Unspecified,
     val inactiveBottomNavIconColor: Color = Color.Unspecified,
     val titleTextColorPrimary: Color = Color.Unspecified,
-    val linkTextColorPrimary: Color = Color.Unspecified,
+    val linkTextColorPrimary: Color = Color.Unspecified
 )
 
 val LocalChaiColorsPalette = staticCompositionLocalOf { ChaiColors() }

--- a/domain/src/main/java/com/android254/domain/models/SessionsInformationDomainModel.kt
+++ b/domain/src/main/java/com/android254/domain/models/SessionsInformationDomainModel.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 DroidconKE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.android254.domain.models
 
 data class SessionsInformationDomainModel(

--- a/presentation/src/main/java/com/android254/presentation/common/bottomnav/BottomNavigationBar.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/bottomnav/BottomNavigationBar.kt
@@ -15,9 +15,12 @@
  */
 package com.android254.presentation.common.bottomnav
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.NavDestination.Companion.hierarchy
@@ -30,23 +33,28 @@ import com.android254.presentation.common.theme.DroidconKE2023Theme
 
 @Composable
 fun BottomNavigationBar(navController: NavHostController) {
-    BottomAppBar(containerColor = MaterialTheme.colorScheme.background) {
+    BottomAppBar(
+        containerColor = MaterialTheme.colorScheme.background
+    ) {
         val navBackStackEntry by navController.currentBackStackEntryAsState()
         val currentDestination = navBackStackEntry?.destination
 
         bottomNavigationDestinations.forEach { destination ->
-            val selected =
-                currentDestination?.hierarchy?.any { it.route == destination.route } == true
             NavigationBarItem(
-                selected = selected,
+                selected = currentDestination?.hierarchy?.any { it.route == destination.route } == true,
                 icon = {
-                    Icon(
-                        painter = painterResource(id = destination.icon),
-                        contentDescription = destination.title
-                    )
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.Center
+                    ) {
+                        Icon(
+                            painter = painterResource(id = destination.icon),
+                            contentDescription = destination.title
+                        )
+                        Text(text = destination.title)
+                    }
                 },
-                label = { Text(text = destination.title) },
-                alwaysShowLabel = true,
+                alwaysShowLabel = false,
                 onClick = {
                     navController.navigate(destination.route) {
                         launchSingleTop = true

--- a/presentation/src/main/java/com/android254/presentation/feed/view/FeedComponent.kt
+++ b/presentation/src/main/java/com/android254/presentation/feed/view/FeedComponent.kt
@@ -63,7 +63,7 @@ fun FeedComponent(
             .wrapContentHeight(),
         shape = RoundedCornerShape(5),
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.onPrimary),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.onPrimary)
     ) {
         Column(
             modifier = Modifier.padding(vertical = 8.dp, horizontal = 16.dp),

--- a/presentation/src/main/java/com/android254/presentation/home/components/HomeHeaderSectionComponent.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/components/HomeHeaderSectionComponent.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 DroidconKE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.android254.presentation.home.components
 
 import androidx.compose.material3.Text
@@ -23,7 +38,7 @@ fun HomeHeaderSectionComponent() {
 
 @ChaiLightAndDarkComposePreview
 @Composable
-private fun HomeHeaderSectionComponentPreview(){
+private fun HomeHeaderSectionComponentPreview() {
     ChaiDCKE22Theme {
         HomeHeaderSectionComponent()
     }

--- a/presentation/src/main/java/com/android254/presentation/home/components/HomeSectionHeaderComponent.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/components/HomeSectionHeaderComponent.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 DroidconKE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.android254.presentation.home.components
 
 import android.content.res.Configuration
@@ -83,7 +98,7 @@ fun HomeSectionHeaderComponent(
                     .width(34.dp)
                     .background(
                         color = MaterialTheme.chaiColorsPalette.linkTextColorPrimary.copy(alpha = 0.11f),
-                        shape = RoundedCornerShape(14.dp),
+                        shape = RoundedCornerShape(14.dp)
                     )
             ) {
                 Text(
@@ -102,11 +117,11 @@ fun HomeSectionHeaderComponent(
 
 @Preview(
     name = "Light",
-    uiMode = Configuration.UI_MODE_NIGHT_NO,
+    uiMode = Configuration.UI_MODE_NIGHT_NO
 )
 @Preview(
     name = "Dark",
-    uiMode = Configuration.UI_MODE_NIGHT_YES,
+    uiMode = Configuration.UI_MODE_NIGHT_YES
 )
 @Composable
 private fun HomeSectionHeaderComponentPreview() {

--- a/presentation/src/main/java/com/android254/presentation/home/components/HomeSessionSection.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/components/HomeSessionSection.kt
@@ -80,7 +80,6 @@ fun HomeSessionSection(
     }
 }
 
-
 @Composable
 fun HomeSessionContent(
     session: SessionPresentationModel,

--- a/presentation/src/main/java/com/android254/presentation/home/components/HomeSpeakerComponent.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/components/HomeSpeakerComponent.kt
@@ -71,7 +71,8 @@ fun HomeSpeakerComponent(speaker: SpeakerUI, onClick: () -> Unit = {}) {
                 )
                 .border(
                     border = BorderStroke(
-                        2.dp, color = colorResource(id = R.color.cyan)
+                        2.dp,
+                        color = colorResource(id = R.color.cyan)
                     ),
                     shape = RoundedCornerShape(12.dp)
                 )

--- a/presentation/src/main/java/com/android254/presentation/home/components/HomeToolbarComponent.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/components/HomeToolbarComponent.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 DroidconKE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.android254.presentation.home.components
 
 import androidx.compose.runtime.Composable
@@ -25,7 +40,6 @@ fun HomeToolbarComponent(
         )
     }
 }
-
 
 @ChaiLightAndDarkComposePreview
 @Composable

--- a/presentation/src/main/java/com/android254/presentation/home/screen/HomeScreen.kt
+++ b/presentation/src/main/java/com/android254/presentation/home/screen/HomeScreen.kt
@@ -52,7 +52,7 @@ fun HomeRoute(
     navigateToFeedbackScreen: () -> Unit = {},
     navigateToSessionScreen: () -> Unit = {},
     onActionClicked: () -> Unit = {},
-    onSessionClicked: (sessionId: String) -> Unit = {},
+    onSessionClicked: (sessionId: String) -> Unit = {}
 ) {
     val homeViewState by homeViewModel.viewState.collectAsStateWithLifecycle()
     val isSyncing by homeViewModel.isSyncing.collectAsStateWithLifecycle()

--- a/presentation/src/main/java/com/android254/presentation/sessions/components/CustomSwitch.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/components/CustomSwitch.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 DroidconKE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.android254.presentation.sessions.components
 
 import androidx.compose.animation.core.animateFloatAsState
@@ -28,7 +43,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.android254.presentation.utils.ChaiLightAndDarkComposePreview
 import com.droidconke.chai.ChaiDCKE22Theme
-
 
 @Composable
 fun CustomSwitch(
@@ -106,7 +120,6 @@ private fun animateAlignmentAsState(
         derivedStateOf { BiasAlignment(horizontalBias = bias, verticalBias = 0f) }
     }
 }
-
 
 @ChaiLightAndDarkComposePreview
 @Composable

--- a/presentation/src/main/java/com/android254/presentation/sessions/components/SessionStateComponent.kt
+++ b/presentation/src/main/java/com/android254/presentation/sessions/components/SessionStateComponent.kt
@@ -59,11 +59,11 @@ fun SessionsStateComponent(
 ) {
     val swipeRefreshState = rememberSwipeRefreshState(isRefreshing = isRefreshing)
 
-    if (sessionsUiState.isLoading){
+    if (sessionsUiState.isLoading) {
         SessionLoadingComponent()
     }
 
-    if (sessionsUiState.isEmpty){
+    if (sessionsUiState.isEmpty) {
         Column(
             modifier = Modifier
                 .fillMaxSize(),
@@ -89,11 +89,11 @@ fun SessionsStateComponent(
         }
     }
 
-    if (sessionsUiState.isError){
+    if (sessionsUiState.isError) {
         SessionsErrorComponent(errorMessage = sessionsUiState.errorMessage, retry = retry)
     }
 
-    if (!sessionsUiState.isEmpty){
+    if (!sessionsUiState.isEmpty) {
         SessionListComponent(
             swipeRefreshState = swipeRefreshState,
             sessions = sessionsUiState.sessions,

--- a/presentation/src/main/java/com/android254/presentation/speakers/view/SpeakersScreen.kt
+++ b/presentation/src/main/java/com/android254/presentation/speakers/view/SpeakersScreen.kt
@@ -68,6 +68,7 @@ fun SpeakersRoute(
         navigateToSpeaker = navigateToSpeaker
     )
 }
+
 @Composable
 private fun SpeakersScreen(
     uiState: SpeakersScreenUiState,
@@ -82,7 +83,7 @@ private fun SpeakersScreen(
                         text = stringResource(id = R.string.speakers_label),
                         fontSize = 24.sp,
                         fontFamily = FontFamily(Font(R.font.montserrat_regular)),
-                        color = MaterialTheme.chaiColorsPalette.textColorPrimary,
+                        color = MaterialTheme.chaiColorsPalette.textColorPrimary
                     )
                 },
                 navigationIcon = {

--- a/presentation/src/main/java/com/android254/presentation/utils/ChaiLightAndDarkComposePreview.kt
+++ b/presentation/src/main/java/com/android254/presentation/utils/ChaiLightAndDarkComposePreview.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 DroidconKE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.android254.presentation.utils
 
 import android.content.res.Configuration

--- a/presentation/src/test/java/com/android254/presentation/sessions/view/SessionScreenTest.kt
+++ b/presentation/src/test/java/com/android254/presentation/sessions/view/SessionScreenTest.kt
@@ -50,7 +50,6 @@ class SessionScreenTest {
 
     @Test
     fun hasExpectedButtons() = runTest {
-
         composeTestRule.setContent {
             DroidconKE2023Theme {
                 SessionsScreen(
@@ -78,7 +77,6 @@ class SessionScreenTest {
 
     @Test
     fun `should show topBar`() = runTest {
-
         composeTestRule.setContent {
             DroidconKE2023Theme() {
                 SessionsScreen(


### PR DESCRIPTION
# Scope

_Please make sure to read the [Contribution Guidelines](https://github.com/droidconKE/droidconKE2023Android/blob/main/CONTRIBUTING.md)
and check that you understand and have followed it as best as possible Explain what your feature
does in a short paragraph._ please check the below boxes
- [x] I have followed the coding conventions
- [x] I have added/updated necessary tests
- [x] I have tested the changes added on a physical device
- [x] I have run `./codeAnalysis.sh` on linux/unix or `codeAnalysys.bat` on windows to make sure all lint/formatting checks have been done.

## Closes/Fixes Issues
Clicking the bottom bar menu items had a wierd effect, of only highlighting icons, and not atleast most of the bottom menu options.

## Other testing QA Notes
Pressing 

a button on the bottombar looked kind of wierd, as the bottom text wasn't highlighted but the small picture only.

Please add a screenshot (if necessary)
Before
<img width="229" alt="before" src="https://github.com/droidconKE/droidconKeKotlin/assets/3319843/3c1524c1-fe3f-492c-b0fe-f5dff8e0fd07">

After
<img width="231" alt="new" src="https://github.com/droidconKE/droidconKeKotlin/assets/3319843/d62abf16-14bc-4da2-8da2-60c28bfdcd1d">
