### PR TITLE
update action cache version to v4 from deprecated v1

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -31,7 +31,7 @@ jobs:
           java-version: '17'
 
       - name: Cache gradle
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
@@ -39,7 +39,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Bundler cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: $CACHE_BUNDLER
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}


### PR DESCRIPTION
# Scope
This PR fixes the PR CI/CD failure and updates action cache version to v4 from deprecated v1
_Please make sure to read the [Contribution Guidelines](https://github.com/droidconKE/droidconKE2023Android/blob/main/CONTRIBUTING.md)
and check that you understand and have followed it as best as possible Explain what your feature
does in a short paragraph._ please check the below boxes
- [x] I have followed the coding conventions
- [ ] I have added/updated necessary tests
- [x] I have tested the changes added on a physical device
- [ ] I have run `./codeAnalysis.sh` on linux/unix or `codeAnalysys.bat` on windows to make sure all lint/formatting checks have been done.

## Closes/Fixes Issues
Fixes #322 

## Other testing QA Notes

Please add a screenshot (if necessary)
