### PR TITLE
Handle edge-to-edge and window insets

### DIFF
--- a/chai/src/main/java/com/droidconke/chai/Theme.kt
+++ b/chai/src/main/java/com/droidconke/chai/Theme.kt
@@ -24,7 +24,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.SideEffect
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 import com.droidconke.chai.colors.ChaiColors
@@ -43,8 +42,6 @@ fun ChaiTheme(
     if (!view.isInEditMode) {
         SideEffect {
             val window = view.context.findActivity()?.window ?: return@SideEffect
-            @Suppress("DEPRECATION")
-            window.statusBarColor = customColorsPalette.background.toArgb()
             WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !darkTheme
         }
     }

--- a/presentation/src/main/java/com/android254/presentation/activity/MainActivity.kt
+++ b/presentation/src/main/java/com/android254/presentation/activity/MainActivity.kt
@@ -21,9 +21,11 @@ import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
@@ -60,6 +62,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         val splashScreen = installSplashScreen()
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
 
         splashScreen.setKeepOnScreenCondition { viewModel.isInitialising.value }
 
@@ -135,7 +138,8 @@ fun MainScreen(
         Column(
             modifier =
                 Modifier
-                    .padding(padding),
+                    .padding(padding)
+                    .consumeWindowInsets(padding),
         ) {
             if (showAuthDialog) {
                 AuthDialog(


### PR DESCRIPTION
targetSdk 37 enforces edge-to-edge, but the app did no insets handling. The only status-bar code was a `window.statusBarColor` write that is a no-op on API 35+, and the root Scaffold plus each screen's nested Scaffold both applied system-bar insets, so the insets were reserved twice.

This enables edge-to-edge explicitly, consumes the insets once at the root so nested Scaffolds do not re-apply them, and drops the dead status-bar write. Status-bar icon contrast still tracks the theme.

Verified with `spotlessCheck ktlintCheck detekt`, `assembleDebug`, and the `chai` and `presentation` unit tests, plus a manual check on a Pixel 7 Pro (API 37) with Home in light and dark. No visual regression.
